### PR TITLE
fix(a11y): improve dropdown keyboard accessibility

### DIFF
--- a/js/modules/bank-search.js
+++ b/js/modules/bank-search.js
@@ -3,6 +3,7 @@ import { copyToClipboard } from '../utils/toast.js';
 import { isPidgin } from './pidgin-toggle.js';
 
 let selectedBankIndex = -1;
+let focusedItemIndex = -1; // ADD THIS
 
 export function initBankSearch() {
   const bankSearch = document.getElementById('bankSearch');
@@ -31,17 +32,22 @@ export function initBankSearch() {
       item.className = "dropdown-item";
       item.setAttribute('role', 'option');
       item.setAttribute('data-index', index);
+      item.setAttribute('tabindex', '-1'); // ADD THIS - makes it programmatically focusable
+      item.setAttribute('id', `bank-item-${Date.now()}-${index}`); // ADD THIS - unique ID for aria-activedescendant
       item.innerHTML = `<span>${b.name}</span><strong>${b.code}</strong>`;
       item.onclick = () => {
         copyToClipboard(b.code, isPidgin, b.name + " code");
         bankSearch.value = b.name;
         bankList.style.display = 'none';
         bankSearch.setAttribute('aria-expanded', 'false');
+        bankSearch.focus(); // ADD THIS - return focus to search input
       };
       bankList.appendChild(item);
     });
 
     selectedBankIndex = -1;
+    focusedItemIndex = -1;
+    bankSearch.removeAttribute('aria-activedescendant'); // ADD THIS
   }
 
   function updateSelectedBank(items) {
@@ -50,6 +56,7 @@ export function initBankSearch() {
         item.style.background = 'var(--primary)';
         item.style.color = 'white';
         item.scrollIntoView({ block: 'nearest' });
+        bankSearch.setAttribute('aria-activedescendant', item.id); // ADD THIS
       } else {
         item.style.background = '';
         item.style.color = '';
@@ -66,8 +73,23 @@ export function initBankSearch() {
   bankSearch.addEventListener('input', (e) => {
     renderBanks(e.target.value);
     selectedBankIndex = -1;
+    focusedItemIndex = -1;
   });
 
+  // ADD THIS - Tab key trap for accessibility
+  bankSearch.addEventListener('keydown', (e) => {
+    if (e.key === 'Tab' && bankList.style.display === 'block') {
+      e.preventDefault(); // Stop focus from leaving dropdown
+      const items = bankList.querySelectorAll('.dropdown-item');
+      if (items.length > 0) {
+        focusedItemIndex = 0;
+        items[0].focus();
+        bankSearch.setAttribute('aria-activedescendant', items[0].id);
+      }
+    }
+  });
+
+  // MODIFY this existing keydown handler - add aria-activedescendant update
   bankSearch.addEventListener('keydown', (e) => {
     const items = bankList.querySelectorAll('.dropdown-item');
     if (items.length === 0) return;
@@ -86,7 +108,40 @@ export function initBankSearch() {
     } else if (e.key === 'Escape') {
       bankList.style.display = 'none';
       bankSearch.setAttribute('aria-expanded', 'false');
+      bankSearch.setAttribute('aria-activedescendant', ''); // ADD THIS
       selectedBankIndex = -1;
+      focusedItemIndex = -1;
+      bankSearch.focus(); // ADD THIS
+    }
+  });
+
+  // ADD THIS - Handle focus leaving dropdown items
+  bankList.addEventListener('keydown', (e) => {
+    if (e.key === 'Tab' && bankList.style.display === 'block') {
+      e.preventDefault();
+      // Shift+Tab goes back to search, Tab stays in dropdown
+      const items = bankList.querySelectorAll('.dropdown-item');
+      const focused = document.activeElement;
+      const currentIndex = Array.from(items).indexOf(focused);
+      
+      if (e.shiftKey) {
+        // Shift+Tab: go back to search
+        bankSearch.focus();
+        bankSearch.setAttribute('aria-activedescendant', items[selectedBankIndex]?.id || '');
+      } else {
+        // Tab: cycle to next item
+        let nextIndex = currentIndex + 1;
+        if (nextIndex < items.length) {
+          items[nextIndex].focus();
+          bankSearch.setAttribute('aria-activedescendant', items[nextIndex].id);
+          selectedBankIndex = nextIndex;
+        } else {
+          // Loop back to first item
+          items[0].focus();
+          bankSearch.setAttribute('aria-activedescendant', items[0].id);
+          selectedBankIndex = 0;
+        }
+      }
     }
   });
 
@@ -94,6 +149,9 @@ export function initBankSearch() {
     if (!bankSearch.contains(e.target) && !bankList.contains(e.target)) {
       bankList.style.display = 'none';
       bankSearch.setAttribute('aria-expanded', 'false');
+      bankSearch.setAttribute('aria-activedescendant', ''); // ADD THIS
+      selectedBankIndex = -1;
+      focusedItemIndex = -1;
     }
   });
 

--- a/js/modules/ussd-search.js
+++ b/js/modules/ussd-search.js
@@ -3,6 +3,7 @@ import { copyToClipboard } from '../utils/toast.js';
 import { isPidgin } from './pidgin-toggle.js';
 
 let selectedUssdIndex = -1;
+let focusedUssdIndex = -1; // ADD THIS
 
 export function initUssdSearch() {
   const ussdSearch = document.getElementById('ussdSearch');
@@ -32,17 +33,22 @@ export function initUssdSearch() {
       item.className = "dropdown-item";
       item.setAttribute('role', 'option');
       item.setAttribute('data-index', index);
+      item.setAttribute('tabindex', '-1'); // ADD THIS - programmatically focusable
+      item.setAttribute('id', `ussd-item-${Date.now()}-${index}`); // ADD THIS - unique ID for aria-activedescendant
       item.innerHTML = `<span>${u.service}</span><strong>${u.code}</strong>`;
       item.onclick = () => {
         copyToClipboard(u.code, isPidgin, u.service);
         ussdSearch.value = u.service;
         ussdList.style.display = 'none';
         ussdSearch.setAttribute('aria-expanded', 'false');
+        ussdSearch.focus(); // ADD THIS - return focus to search input
       };
       ussdList.appendChild(item);
     });
 
     selectedUssdIndex = -1;
+    focusedUssdIndex = -1;
+    ussdSearch.removeAttribute('aria-activedescendant'); // ADD THIS
   }
 
   function updateSelectedUssd(items) {
@@ -51,6 +57,7 @@ export function initUssdSearch() {
         item.style.background = 'var(--primary)';
         item.style.color = 'white';
         item.scrollIntoView({ block: 'nearest' });
+        ussdSearch.setAttribute('aria-activedescendant', item.id); // ADD THIS
       } else {
         item.style.background = '';
         item.style.color = '';
@@ -67,8 +74,23 @@ export function initUssdSearch() {
   ussdSearch.addEventListener('input', (e) => {
     renderUssd(e.target.value);
     selectedUssdIndex = -1;
+    focusedUssdIndex = -1;
   });
 
+  // ADD THIS - Tab key trap for accessibility
+  ussdSearch.addEventListener('keydown', (e) => {
+    if (e.key === 'Tab' && ussdList.style.display === 'block') {
+      e.preventDefault(); // Stop focus from leaving dropdown
+      const items = ussdList.querySelectorAll('.dropdown-item');
+      if (items.length > 0) {
+        focusedUssdIndex = 0;
+        items[0].focus();
+        ussdSearch.setAttribute('aria-activedescendant', items[0].id);
+      }
+    }
+  });
+
+  // MODIFY this existing keydown handler - add aria-activedescendant update
   ussdSearch.addEventListener('keydown', (e) => {
     const items = ussdList.querySelectorAll('.dropdown-item');
     if (items.length === 0) return;
@@ -87,7 +109,40 @@ export function initUssdSearch() {
     } else if (e.key === 'Escape') {
       ussdList.style.display = 'none';
       ussdSearch.setAttribute('aria-expanded', 'false');
+      ussdSearch.setAttribute('aria-activedescendant', ''); // ADD THIS
       selectedUssdIndex = -1;
+      focusedUssdIndex = -1;
+      ussdSearch.focus(); // ADD THIS
+    }
+  });
+
+  // ADD THIS - Handle focus leaving dropdown items
+  ussdList.addEventListener('keydown', (e) => {
+    if (e.key === 'Tab' && ussdList.style.display === 'block') {
+      e.preventDefault();
+      // Shift+Tab goes back to search, Tab stays in dropdown
+      const items = ussdList.querySelectorAll('.dropdown-item');
+      const focused = document.activeElement;
+      const currentIndex = Array.from(items).indexOf(focused);
+      
+      if (e.shiftKey) {
+        // Shift+Tab: go back to search
+        ussdSearch.focus();
+        ussdSearch.setAttribute('aria-activedescendant', items[selectedUssdIndex]?.id || '');
+      } else {
+        // Tab: cycle to next item
+        let nextIndex = currentIndex + 1;
+        if (nextIndex < items.length) {
+          items[nextIndex].focus();
+          ussdSearch.setAttribute('aria-activedescendant', items[nextIndex].id);
+          selectedUssdIndex = nextIndex;
+        } else {
+          // Loop back to first item
+          items[0].focus();
+          ussdSearch.setAttribute('aria-activedescendant', items[0].id);
+          selectedUssdIndex = 0;
+        }
+      }
     }
   });
 
@@ -95,6 +150,9 @@ export function initUssdSearch() {
     if (!ussdSearch.contains(e.target) && !ussdList.contains(e.target)) {
       ussdList.style.display = 'none';
       ussdSearch.setAttribute('aria-expanded', 'false');
+      ussdSearch.setAttribute('aria-activedescendant', ''); // ADD THIS
+      selectedUssdIndex = -1;
+      focusedUssdIndex = -1;
     }
   });
 


### PR DESCRIPTION
## Description
This PR improves accessibility for keyboard and screen reader users in both the Bank Codes and USSD Codes search dropdowns.

## Changes Made
- **Tab trapping**: Focus stays inside dropdown when open (prevents users from losing their place)
- **Focusable items**: Dropdown items now have `tabindex="-1"` for programmatic focus
- **ARIA attributes**: `aria-activedescendant` tracks and announces selected items to screen readers
- **Focus management**: Focus returns to search input after copying a code or closing dropdown
- **Navigation**: Shift+Tab navigates back to search input, Tab cycles through dropdown items
- **Cleanup**: ARIA attributes properly cleared on Escape key

## Testing Done
- [x] Keyboard-only navigation (Tab, Arrow keys, Enter, Escape, Shift+Tab)
- [x] Screen reader testing (NVDA)
- [x] Works in both light and dark mode
- [x] Works with Pidgin toggle on/off

## Related Issue
Closes #6 
